### PR TITLE
crypto/kz4844: pass blobs by ref

### DIFF
--- a/crypto/kzg4844/kzg4844.go
+++ b/crypto/kzg4844/kzg4844.go
@@ -65,7 +65,7 @@ func UseCKZG(use bool) error {
 }
 
 // BlobToCommitment creates a small commitment out of a data blob.
-func BlobToCommitment(blob Blob) (Commitment, error) {
+func BlobToCommitment(blob *Blob) (Commitment, error) {
 	if useCKZG.Load() {
 		return ckzgBlobToCommitment(blob)
 	}
@@ -74,7 +74,7 @@ func BlobToCommitment(blob Blob) (Commitment, error) {
 
 // ComputeProof computes the KZG proof at the given point for the polynomial
 // represented by the blob.
-func ComputeProof(blob Blob, point Point) (Proof, Claim, error) {
+func ComputeProof(blob *Blob, point Point) (Proof, Claim, error) {
 	if useCKZG.Load() {
 		return ckzgComputeProof(blob, point)
 	}
@@ -94,7 +94,7 @@ func VerifyProof(commitment Commitment, point Point, claim Claim, proof Proof) e
 // the commitment.
 //
 // This method does not verify that the commitment is correct with respect to blob.
-func ComputeBlobProof(blob Blob, commitment Commitment) (Proof, error) {
+func ComputeBlobProof(blob *Blob, commitment Commitment) (Proof, error) {
 	if useCKZG.Load() {
 		return ckzgComputeBlobProof(blob, commitment)
 	}
@@ -102,7 +102,7 @@ func ComputeBlobProof(blob Blob, commitment Commitment) (Proof, error) {
 }
 
 // VerifyBlobProof verifies that the blob data corresponds to the provided commitment.
-func VerifyBlobProof(blob Blob, commitment Commitment, proof Proof) error {
+func VerifyBlobProof(blob *Blob, commitment Commitment, proof Proof) error {
 	if useCKZG.Load() {
 		return ckzgVerifyBlobProof(blob, commitment, proof)
 	}

--- a/crypto/kzg4844/kzg4844_ckzg_cgo.go
+++ b/crypto/kzg4844/kzg4844_ckzg_cgo.go
@@ -61,10 +61,10 @@ func ckzgInit() {
 }
 
 // ckzgBlobToCommitment creates a small commitment out of a data blob.
-func ckzgBlobToCommitment(blob Blob) (Commitment, error) {
+func ckzgBlobToCommitment(blob *Blob) (Commitment, error) {
 	ckzgIniter.Do(ckzgInit)
 
-	commitment, err := ckzg4844.BlobToKZGCommitment((ckzg4844.Blob)(blob))
+	commitment, err := ckzg4844.BlobToKZGCommitment((*ckzg4844.Blob)(blob))
 	if err != nil {
 		return Commitment{}, err
 	}
@@ -73,10 +73,10 @@ func ckzgBlobToCommitment(blob Blob) (Commitment, error) {
 
 // ckzgComputeProof computes the KZG proof at the given point for the polynomial
 // represented by the blob.
-func ckzgComputeProof(blob Blob, point Point) (Proof, Claim, error) {
+func ckzgComputeProof(blob *Blob, point Point) (Proof, Claim, error) {
 	ckzgIniter.Do(ckzgInit)
 
-	proof, claim, err := ckzg4844.ComputeKZGProof((ckzg4844.Blob)(blob), (ckzg4844.Bytes32)(point))
+	proof, claim, err := ckzg4844.ComputeKZGProof((*ckzg4844.Blob)(blob), (ckzg4844.Bytes32)(point))
 	if err != nil {
 		return Proof{}, Claim{}, err
 	}
@@ -102,10 +102,10 @@ func ckzgVerifyProof(commitment Commitment, point Point, claim Claim, proof Proo
 // the commitment.
 //
 // This method does not verify that the commitment is correct with respect to blob.
-func ckzgComputeBlobProof(blob Blob, commitment Commitment) (Proof, error) {
+func ckzgComputeBlobProof(blob *Blob, commitment Commitment) (Proof, error) {
 	ckzgIniter.Do(ckzgInit)
 
-	proof, err := ckzg4844.ComputeBlobKZGProof((ckzg4844.Blob)(blob), (ckzg4844.Bytes48)(commitment))
+	proof, err := ckzg4844.ComputeBlobKZGProof((*ckzg4844.Blob)(blob), (ckzg4844.Bytes48)(commitment))
 	if err != nil {
 		return Proof{}, err
 	}
@@ -113,10 +113,10 @@ func ckzgComputeBlobProof(blob Blob, commitment Commitment) (Proof, error) {
 }
 
 // ckzgVerifyBlobProof verifies that the blob data corresponds to the provided commitment.
-func ckzgVerifyBlobProof(blob Blob, commitment Commitment, proof Proof) error {
+func ckzgVerifyBlobProof(blob *Blob, commitment Commitment, proof Proof) error {
 	ckzgIniter.Do(ckzgInit)
 
-	valid, err := ckzg4844.VerifyBlobKZGProof((ckzg4844.Blob)(blob), (ckzg4844.Bytes48)(commitment), (ckzg4844.Bytes48)(proof))
+	valid, err := ckzg4844.VerifyBlobKZGProof((*ckzg4844.Blob)(blob), (ckzg4844.Bytes48)(commitment), (ckzg4844.Bytes48)(proof))
 	if err != nil {
 		return err
 	}

--- a/crypto/kzg4844/kzg4844_ckzg_nocgo.go
+++ b/crypto/kzg4844/kzg4844_ckzg_nocgo.go
@@ -32,13 +32,13 @@ func ckzgInit() {
 }
 
 // ckzgBlobToCommitment creates a small commitment out of a data blob.
-func ckzgBlobToCommitment(blob Blob) (Commitment, error) {
+func ckzgBlobToCommitment(blob *Blob) (Commitment, error) {
 	panic("unsupported platform")
 }
 
 // ckzgComputeProof computes the KZG proof at the given point for the polynomial
 // represented by the blob.
-func ckzgComputeProof(blob Blob, point Point) (Proof, Claim, error) {
+func ckzgComputeProof(blob *Blob, point Point) (Proof, Claim, error) {
 	panic("unsupported platform")
 }
 
@@ -52,11 +52,11 @@ func ckzgVerifyProof(commitment Commitment, point Point, claim Claim, proof Proo
 // the commitment.
 //
 // This method does not verify that the commitment is correct with respect to blob.
-func ckzgComputeBlobProof(blob Blob, commitment Commitment) (Proof, error) {
+func ckzgComputeBlobProof(blob *Blob, commitment Commitment) (Proof, error) {
 	panic("unsupported platform")
 }
 
 // ckzgVerifyBlobProof verifies that the blob data corresponds to the provided commitment.
-func ckzgVerifyBlobProof(blob Blob, commitment Commitment, proof Proof) error {
+func ckzgVerifyBlobProof(blob *Blob, commitment Commitment, proof Proof) error {
 	panic("unsupported platform")
 }

--- a/crypto/kzg4844/kzg4844_gokzg.go
+++ b/crypto/kzg4844/kzg4844_gokzg.go
@@ -46,10 +46,10 @@ func gokzgInit() {
 }
 
 // gokzgBlobToCommitment creates a small commitment out of a data blob.
-func gokzgBlobToCommitment(blob Blob) (Commitment, error) {
+func gokzgBlobToCommitment(blob *Blob) (Commitment, error) {
 	gokzgIniter.Do(gokzgInit)
 
-	commitment, err := context.BlobToKZGCommitment((gokzg4844.Blob)(blob), 0)
+	commitment, err := context.BlobToKZGCommitment((*gokzg4844.Blob)(blob), 0)
 	if err != nil {
 		return Commitment{}, err
 	}
@@ -58,10 +58,10 @@ func gokzgBlobToCommitment(blob Blob) (Commitment, error) {
 
 // gokzgComputeProof computes the KZG proof at the given point for the polynomial
 // represented by the blob.
-func gokzgComputeProof(blob Blob, point Point) (Proof, Claim, error) {
+func gokzgComputeProof(blob *Blob, point Point) (Proof, Claim, error) {
 	gokzgIniter.Do(gokzgInit)
 
-	proof, claim, err := context.ComputeKZGProof((gokzg4844.Blob)(blob), (gokzg4844.Scalar)(point), 0)
+	proof, claim, err := context.ComputeKZGProof((*gokzg4844.Blob)(blob), (gokzg4844.Scalar)(point), 0)
 	if err != nil {
 		return Proof{}, Claim{}, err
 	}
@@ -80,10 +80,10 @@ func gokzgVerifyProof(commitment Commitment, point Point, claim Claim, proof Pro
 // the commitment.
 //
 // This method does not verify that the commitment is correct with respect to blob.
-func gokzgComputeBlobProof(blob Blob, commitment Commitment) (Proof, error) {
+func gokzgComputeBlobProof(blob *Blob, commitment Commitment) (Proof, error) {
 	gokzgIniter.Do(gokzgInit)
 
-	proof, err := context.ComputeBlobKZGProof((gokzg4844.Blob)(blob), (gokzg4844.KZGCommitment)(commitment), 0)
+	proof, err := context.ComputeBlobKZGProof((*gokzg4844.Blob)(blob), (gokzg4844.KZGCommitment)(commitment), 0)
 	if err != nil {
 		return Proof{}, err
 	}
@@ -91,8 +91,8 @@ func gokzgComputeBlobProof(blob Blob, commitment Commitment) (Proof, error) {
 }
 
 // gokzgVerifyBlobProof verifies that the blob data corresponds to the provided commitment.
-func gokzgVerifyBlobProof(blob Blob, commitment Commitment, proof Proof) error {
+func gokzgVerifyBlobProof(blob *Blob, commitment Commitment, proof Proof) error {
 	gokzgIniter.Do(gokzgInit)
 
-	return context.VerifyBlobKZGProof((gokzg4844.Blob)(blob), (gokzg4844.KZGCommitment)(commitment), (gokzg4844.KZGProof)(proof))
+	return context.VerifyBlobKZGProof((*gokzg4844.Blob)(blob), (gokzg4844.KZGCommitment)(commitment), (gokzg4844.KZGProof)(proof))
 }

--- a/crypto/kzg4844/kzg4844_test.go
+++ b/crypto/kzg4844/kzg4844_test.go
@@ -36,13 +36,13 @@ func randFieldElement() [32]byte {
 	return gokzg4844.SerializeScalar(r)
 }
 
-func randBlob() Blob {
+func randBlob() *Blob {
 	var blob Blob
 	for i := 0; i < len(blob); i += gokzg4844.SerializedScalarSize {
 		fieldElementBytes := randFieldElement()
 		copy(blob[i:i+gokzg4844.SerializedScalarSize], fieldElementBytes[:])
 	}
-	return blob
+	return &blob
 }
 
 func TestCKZGWithPoint(t *testing.T)  { testKZGWithPoint(t, true) }


### PR DESCRIPTION
This PR reflects the changes from https://github.com/ethereum/go-ethereum/pull/29050 into suave-geth as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Optimized cryptographic operations by updating function parameters to use pointers, enhancing performance and memory usage.
- **Tests**
	- Adjusted test functions to align with the updated cryptographic function signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->